### PR TITLE
fix typo in run.rst

### DIFF
--- a/engine/reference/run.rst
+++ b/engine/reference/run.rst
@@ -1608,7 +1608,7 @@ NUMA システム上でのみ、どのコンテナをメモリ上で実行する
 
 .. The next table shows the capabilities which are not granted by default and may be added.
 
-次の表は、デフォルトでは許可されていないものおん、追加可能なケーパビリティの一覧です。
+次の表は、デフォルトでは許可されていないものの、追加可能なケーパビリティの一覧です。
 
 
 .. list-table::


### PR DESCRIPTION
軽微な誤字ですが以下の誤字を修正しました。

修正前: デフォルトでは許可されていないものおん
↓
修正後: デフォルトでは許可されていないものの


[CONTRIBUTING.md](https://github.com/zembutsu/docs.docker.jp/blob/v24.0/CONTRIBUTING.md)を確認しましたが、masterブランチがなく最新の修正はv24.0に入っているようだったため、v24.0へプルリクエストを出しました。

mainブランチへプルリクエストを出すべきである場合はお手数をおかけしますが、ご指摘いただけますでしょうか。その際はプルリクエストを作成しなおします。